### PR TITLE
Add an option to show diagnostic source

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ call plug#end()
 ```Lua
 require("echo-diagnostics").setup{
     show_diagnostic_number = true
+    show_diagnostic_source = false
 }
 ```
 

--- a/lua/echo-diagnostics.lua
+++ b/lua/echo-diagnostics.lua
@@ -4,6 +4,7 @@ local cmd = vim.cmd
 -- Options
 local opt = {
     show_diagnostic_number = true,
+    show_diagnostic_source = false,
 }
 
 M.find_line_diagnostic = function(show_entire_diagnostic)
@@ -29,6 +30,9 @@ M.find_line_diagnostic = function(show_entire_diagnostic)
                     msg = msg .. k .. ': '
                 end
                 msg = msg .. diagnostics[k].message
+                if opt.show_diagnostic_source and diagnostics[k].source then
+                    msg = msg .. ' (' .. diagnostics[k].source .. ')'
+                end
                 if k < #diagnostics then
                     msg = msg .. '\n'
                 end


### PR DESCRIPTION
This adds an option to show diagnostic source at the end of the message e.g.
```
'count' is already declared in the upper scope on line 6 column 10. (eslint)
```

This is especially useful for metalinters such as `golangci-lint` which runs multiple linters so the source actually shows the underlining linter that triggers an issue e.g.
```
exported function `MyFunction` should have comment or be unexported (golint)
```

This is also the same behavior that `neomake` implements by default.