### PR TITLE
Add an option to show the diagnostic code

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ call plug#end()
 require('echo-diagnostics').setup({
     show_diagnostic_number = true,
     show_diagnostic_source = false,
+    show_diagnostic_code = false,
 })
 ```
 

--- a/lua/echo-diagnostics.lua
+++ b/lua/echo-diagnostics.lua
@@ -5,6 +5,7 @@ local current_msg = nil
 local opt = {
     show_diagnostic_number = true,
     show_diagnostic_source = false,
+    show_diagnostic_code = false
 }
 
 local function find_line_diagnostic(show_entire_diagnostic)
@@ -23,6 +24,9 @@ local function find_line_diagnostic(show_entire_diagnostic)
     for k, v in pairs(diagnostics) do
         if v.message then
             local msg = opt.show_diagnostic_number and string.format('%s: %s', k, v.message) or v.message
+            if opt.show_diagnostic_code and v.code then
+                msg = msg .. ' [' .. v.code .. ']'
+            end
             if opt.show_diagnostic_source and v.source then
                 msg = msg .. ' (' .. v.source .. ')'
             end


### PR DESCRIPTION
Hello,
First of, thank you for your plugin! I really like it and I have been using it for a while now.
I would like to add the diagnostic code to the output, if it's available. I added a simple option to toggle the behaviour. By default, it's off.

Here is how it looks like:

<img width="734" height="69" alt="screen-2025-07-11-18-47-06" src="https://github.com/user-attachments/assets/cc1a8d98-ed85-438f-9593-776e190722d6" />

This is quite useful when I'm linting a Python file. Ruff has many linting rules and I like knowing what rule specifically triggered the warning